### PR TITLE
copy to avoid modifying the AST

### DIFF
--- a/sigchanyzer.go
+++ b/sigchanyzer.go
@@ -66,12 +66,18 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 
-		chanDecl.Args = append(chanDecl.Args, &ast.BasicLit{
+		// Make a copy of the channel's declaration to avoid
+		// mutating the AST. See https://golang.org/issue/46129.
+		chanDeclCopy := &ast.CallExpr{}
+		*chanDeclCopy = *chanDecl
+		chanDeclCopy.Args = append([]ast.Expr(nil), chanDecl.Args...)
+		chanDeclCopy.Args = append(chanDeclCopy.Args, &ast.BasicLit{
 			Kind:  token.INT,
 			Value: "1",
 		})
+
 		var buf bytes.Buffer
-		if err := format.Node(&buf, token.NewFileSet(), chanDecl); err != nil {
+		if err := format.Node(&buf, token.NewFileSet(), chanDeclCopy); err != nil {
 			return
 		}
 		pass.Report(analysis.Diagnostic{


### PR DESCRIPTION
The sigchanyzer pass suggests fixes, but it does that
by altering the channel declaration argument.
That causes the buildssa.Analyzer fail to fail,
along with crashing other passes that depend on it.

To fix this, we make a copy of the channel's declaration arguments,
and modify the copy instead.

Cherry pick from https://go-review.googlesource.com/c/tools/+/319211